### PR TITLE
Fix murmur64a hash

### DIFF
--- a/source/hasher.cpp
+++ b/source/hasher.cpp
@@ -235,9 +235,9 @@ class hash_murmur_64a : public hellextractor::hash::instance {
 			hash ^= (static_cast<uint64_t>(data2[1]) << 8);
 		case 1:
 			hash ^= (static_cast<uint64_t>(data2[0]));
+			hash *= mix;
 		};
 
-		hash *= mix;
 		hash ^= hash >> shifts;
 
 		hash *= mix;


### PR DESCRIPTION
Previously, calculated hashes would be wrong if input length was a multiple of 8.

An example of such a wrong hash calculation is the string "content/audio/wep_colony_shotgun".
Using the current upstream version, the hash is wrongly calculated as cc54dec1972bc218. The correct hash for this string is d8a50cd49f4b1c59, which this patched version produces.